### PR TITLE
Fix autoderef syntax error

### DIFF
--- a/lib/HADaemon/Control.pm
+++ b/lib/HADaemon/Control.pm
@@ -907,7 +907,7 @@ sub _create_dir {
         }
 
         make_path($dir, $make_path_args);
-        @$errors and $self->die("failed make_path: " . join(' ', map { keys $_, values $_ } @$errors));
+        @$errors and $self->die("failed make_path: " . join(' ', map { keys %$_, values %$_ } @$errors));
         $self->trace("Created dir ($dir)");
     }
 }


### PR DESCRIPTION
It's been an error since perl 5.20